### PR TITLE
Add tests to verify authorization in contract methods

### DIFF
--- a/src/tests/config/contract.rs
+++ b/src/tests/config/contract.rs
@@ -16,7 +16,6 @@ pub struct ContractTest<'a> {
 impl<'a> ContractTest<'a> {
     pub fn setup() -> Self {
         let env = Env::default();
-        env.mock_all_auths();
 
         let admin = Address::generate(&env);
         let token_issuer = Address::generate(&env);
@@ -26,10 +25,13 @@ impl<'a> ContractTest<'a> {
 
         let (token_client, token_admin) = create_token_contract(&env, &token_issuer);
 
-        token_admin.mint(&user_a, &BASE_MINT_AMOUNT);
-        token_admin.mint(&user_b, &BASE_MINT_AMOUNT);
+        token_admin
+            .mock_all_auths()
+            .mint(&user_a, &BASE_MINT_AMOUNT);
+        token_admin
+            .mock_all_auths()
+            .mint(&user_b, &BASE_MINT_AMOUNT);
 
-        
         let contract_id = env.register(Contract, (&admin,));
         let contract = ContractClient::new(&env, &contract_id);
 

--- a/src/tests/contract.rs
+++ b/src/tests/contract.rs
@@ -1,15 +1,19 @@
-
-use crate::{storage::types::storage::DataKey, tests::config::{constants::BASE_MINT_AMOUNT, contract::ContractTest}};
+use crate::{
+    storage::types::storage::DataKey,
+    tests::config::{constants::BASE_MINT_AMOUNT, contract::ContractTest},
+};
+use soroban_sdk::{
+    testutils::{MockAuth, MockAuthInvoke},
+    IntoVal,
+};
 
 #[test]
 fn set_admin_test() {
     let ContractTest {
-        contract,
-        user_a,
-        ..
+        contract, user_a, ..
     } = ContractTest::setup();
 
-    contract.set_admin(&user_a);
+    contract.mock_all_auths().set_admin(&user_a);
 }
 
 #[test]
@@ -23,18 +27,42 @@ fn set_admin_fail_test() {
     } = ContractTest::setup();
 
     let contract_id = contract.address.clone();
-    
+
     let key = DataKey::Admin;
     env.as_contract(&contract_id, || {
         env.storage().instance().remove(&key);
     });
 
-    contract.set_admin(&admin);
+    contract.mock_all_auths().set_admin(&admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+pub fn set_admin_with_unauthorized_admin_test() {
+    let ContractTest {
+        env,
+        contract,
+        user_a,
+        ..
+    } = ContractTest::setup();
+
+    contract
+        .mock_auths(&[MockAuth {
+            address: &user_a,
+            invoke: &MockAuthInvoke {
+                contract: &contract.address.clone(),
+                fn_name: "set_admin",
+                args: (user_a.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .set_admin(&user_a);
 }
 
 #[test]
 fn transfer_test() {
     let ContractTest {
+        env,
         contract,
         user_a,
         user_b,
@@ -42,7 +70,8 @@ fn transfer_test() {
         ..
     } = ContractTest::setup();
 
-    let (token_client, _, __) = token;
+    env.mock_all_auths();
+    let (token_client, _, _) = token;
 
     let transfer_amount = BASE_MINT_AMOUNT / 2;
 
@@ -62,8 +91,10 @@ fn transfer_test() {
 }
 
 #[test]
-fn get_user_test() {
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+pub fn transfer_with_unauthorized_sender_test() {
     let ContractTest {
+        env,
         contract,
         user_a,
         user_b,
@@ -71,7 +102,45 @@ fn get_user_test() {
         ..
     } = ContractTest::setup();
 
-    let (token_client, _, __) = token;
+    env.mock_all_auths();
+    let (token_client, _, _) = token;
+
+    let transfer_amount = BASE_MINT_AMOUNT / 2;
+
+    assert_eq!(token_client.balance(&user_a), BASE_MINT_AMOUNT);
+    assert_eq!(token_client.balance(&user_b), BASE_MINT_AMOUNT);
+
+    contract
+        .mock_auths(&[MockAuth {
+            address: &user_b,
+            invoke: &MockAuthInvoke {
+                contract: &contract.address.clone(),
+                fn_name: "set_admin",
+                args: (
+                    user_a.clone(),
+                    user_b.clone(),
+                    token_client.address.clone(),
+                    transfer_amount,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .transfer(&user_a, &user_b, &token_client.address, &transfer_amount);
+}
+
+#[test]
+fn get_user_test() {
+    let ContractTest {
+        env,
+        contract,
+        user_a,
+        user_b,
+        token,
+        ..
+    } = ContractTest::setup();
+    env.mock_all_auths();
+    let (token_client, _, _) = token;
 
     let transfer_amount = BASE_MINT_AMOUNT / 2;
 
@@ -92,5 +161,5 @@ fn get_user_fail_test() {
         contract, user_a, ..
     } = ContractTest::setup();
 
-    contract.get_user(&user_a);
+    contract.mock_all_auths().get_user(&user_a);
 }


### PR DESCRIPTION
# Summary

This pull request adds validations in the tests to corroborate that whoever executes the contract methods and signs the transactions is the authorized user.

# Details

- Removes the need to mock all contract validations, enabling individual test coverage,
- Added tests to verify that only authorized addresses can execute contract methods
