### PR TITLE
Add rusty-hook with pre-commit and pre-push hooks

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,6 @@
+[hooks]
+pre-commit = "cargo fmt && cargo check && cargo test"
+pre-push = "cargo fmt && cargo check"
+
+[logging]
+verbose = true

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,6 +1,6 @@
 [hooks]
-pre-commit = "cargo fmt && cargo check && cargo test"
-pre-push = "cargo fmt && cargo check"
+pre-commit = "cargo fmt && cargo check"
+pre-push = "cargo fmt && cargo check  && cargo test"
 
 [logging]
 verbose = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ soroban-sdk = { version = "22.0.7" }
 
 [dev_dependencies]
 soroban-sdk = { version = "22.0.7", features = ["testutils"] }
+rusty-hook = "0.11.2"
 
 [features]
 testutils = ["soroban-sdk/testutils"]


### PR DESCRIPTION
# Summary

This pull request adds `rusty-hook` to enforce code formatting, linting, and testing during development.

# Details

Hook configuration added to `.rusty-hook.toml`:
- `pre-commit:` runs cargo fmt and cargo check to ensure code style and syntax are valid before committing.
- `pre-push:` runs cargo fmt, cargo check, and cargo test to ensure code is formatted, compiles, and passes all tests before pushing.

# References

[rusty-hook dependency](https://crates.io/crates/rusty-hook/0.11.2)
